### PR TITLE
Copy boost dll files step only required on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,16 +490,18 @@ ExternalProject_Add(boost
     INSTALL_DIR ${SDK_INSTALL_DIR}/Boost
 )
 
-ExternalProject_Add_Step(boost
-    copyDLL
-    DEPENDEES install
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake --
-        <INSTALL_DIR>/lib/*.dll
-        ${SDK_INSTALL_DIR}/bin/
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/DeleteFiles.cmake --
-        <INSTALL_DIR>/lib/*.dll
-    COMMENT "Copy boost dll files into SDK bin directory"
-)
+if(WIN32)
+	ExternalProject_Add_Step(boost
+		copyDLL
+		DEPENDEES install
+		COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake --
+			<INSTALL_DIR>/lib/*.dll
+			${SDK_INSTALL_DIR}/bin/
+		COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/DeleteFiles.cmake --
+			<INSTALL_DIR>/lib/*.dll
+		COMMENT "Copy boost dll files into SDK bin directory"
+	)
+endif()
 
 ExternalProject_Add_Step(boost
     removeExtraPDB


### PR DESCRIPTION
On OSX, this step causes an error (because the source dll files aren't found of course). Pretty sure that this step should only happen on Windows, but not 100%, so I decided to make a PR first.