### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 os:
   - osx
-osx_image:
-  - xcode6.4
-language:
-  - c++
+osx_image: xcode6.4
+language: cpp
 before_script:
   - mkdir build
   - cd build


### PR DESCRIPTION
- `osx_image:` and `language:` keys don't support array values
-  `c++` isn't a supported value for `language:` key. Changed it to `cpp`. Cf. https://docs.travis-ci.com/user/languages/cpp