### PR TITLE
Fix `failed to write output file` error during boost compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,6 +630,7 @@ ExternalProject_Add(boost
         toolset=${BOOST_TOOLSET}
         -d
         --debug-configuration
+        --abbreviate-paths
         --user-config=${CMAKE_BINARY_DIR}/boost-config.jam
         --without-context
         --without-coroutine


### PR DESCRIPTION
If resulting path very long Windows returns error `failed to write output file`.