### PR TITLE
Mac SDK change from i386 to x86_64, compile with visibility=hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,13 @@ set(DIST_PACK_TARGETS )
 if(APPLE)
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build external projects except for Boost as static libraries" FORCE)
     set(SDK_INSTALL_DIR "${SDK_INSTALL_DIR}/dep")
+
+# CMake sets the value for OSX_SYSROOT after the project call.
+# Not certain if that is true for older versions of CMake, so provide a default.
+    if(NOT CMAKE_OSX_SYSROOT)
+        set(CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+            CACHE PATH "Use default path to OSX SYSROOT")
+    endif()
 endif()
 
 # Common download directory for all dependency source releases.  Storing
@@ -152,6 +159,13 @@ if(APPLE)
         message(FATAL_ERROR "Unable to locate `hdiutil` executable.")
     endif()
     list(APPEND DIST_PACK_TOOLS hdiutil)
+
+    add_custom_target(installnametool)
+    find_program(INAMETOOL_EXECUTABLE install_name_tool)
+    if(NOT INAMETOOL_EXECUTABLE)
+        message(FATAL_ERROR "Unable to locate `install_name_tool` executable.")
+    endif()
+    list(APPEND DIST_PACK_TOOLS installnametool)
 endif()
 
 ExternalProject_PatchSet(zlib ZLIB_PATCHSET)
@@ -555,7 +569,7 @@ else()
 endif()
 string(SUBSTRING "${PYTHON_VERSION}" 0 3 PYTHON_VERSION)
 
-if(BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS OR APPLE)
     set(BOOST_LINK "shared")
 else()
     set(BOOST_LINK "static")
@@ -677,6 +691,54 @@ elseif(APPLE)
         ${CMAKE_COMMAND} -E remove_directory
         ${SDK_INSTALL_DIR}
     )
+
+# Need to make Mac-specific changes to the dylib install_name for
+#    12 libraries that will be copied with the FO executable.
+#This uses the install_name_tool to overwrite those paths.
+# Need to change both the library's id and where it looks for
+#    dependent libraries.
+    set(DYLIB_OSX_NAMES
+        libboost_date_time.dylib
+        libboost_filesystem.dylib
+        libboost_iostreams.dylib
+        libboost_locale.dylib
+        libboost_log.dylib
+        libboost_log_setup.dylib
+        libboost_python.dylib
+        libboost_regex.dylib
+        libboost_serialization.dylib
+        libboost_signals.dylib
+        libboost_system.dylib
+        libboost_thread.dylib
+    )
+# install_name_tool will ignore any cases where the _DYLIB_NAME library
+# does not depend on the _DYLIB_DEPEND library
+    foreach(_DYLIB_NAME IN LISTS DYLIB_OSX_NAMES)
+        add_custom_command(
+            TARGET pre-pack
+	    PRE_BUILD
+            WORKING_DIRECTORY
+                ${SDK_INSTALL_DIR}/lib
+	    COMMAND
+	        ${INAMETOOL_EXECUTABLE} -id
+	            @executable_path/../SharedSupport/${_DYLIB_NAME}
+		    ${SDK_INSTALL_DIR}/lib/${_DYLIB_NAME}
+            )
+        foreach(_DYLIB_DEPEND IN LISTS DYLIB_OSX_NAMES)
+            add_custom_command(
+                TARGET pre-pack
+	        PRE_BUILD
+                WORKING_DIRECTORY
+                    ${SDK_INSTALL_DIR}/lib
+	        COMMAND
+	            ${INAMETOOL_EXECUTABLE} -change
+		    @rpath/${_DYLIB_DEPEND}
+	            @executable_path/../SharedSupport/${_DYLIB_DEPEND}
+		    ${SDK_INSTALL_DIR}/lib/${_DYLIB_NAME}
+            )
+        endforeach(_DYLIB_DEPEND)
+    endforeach(_DYLIB_NAME)
+
     list(APPEND DIST_PACK_TARGETS pre-pack)
 else()
     message(FATAL "Target system not yet supported")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ option(CMAKE_VERBOSE_MAKEFILE "Build with verbose Makefile output." OFF)
 set(DIST_VERSION 7 CACHE STRING "FreeOrionSDK release version.")
 set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard the dependencies should be build with.")
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "Set the minimum OSX deployment target version")
-set(CMAKE_OSX_ARCHITECTURES i386 CACHE STRING "Set the architecture the universal binaries for OSX should be built for")
+set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING "Set the architecture the binaries for OSX should be built for")
 set(CMAKE_INSTALL_MESSAGE NEVER CACHE STRING "Set the verbosity level for the install messages")
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ set(DIST_PACK_TOOLS )
 set(DIST_PACK_TARGETS )
 
 if(APPLE)
-    set(BUILD_SHARED_LIBS OFF)
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build external projects except for Boost as static libraries" FORCE)
     set(SDK_INSTALL_DIR "${SDK_INSTALL_DIR}/dep")
 endif()
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ properly set up:
 
 `cmake ..`
 
+(For a Mac, use the correct generator:
+`cmake -G Xcode ..` )
+
 This command creates a native build system for the SDK. After that the SDK
 can be build with:
 

--- a/patches/boost/0005-macros-for-non-windows.patch
+++ b/patches/boost/0005-macros-for-non-windows.patch
@@ -1,0 +1,115 @@
+Boost has certain preprocessor macros that only work for Windows.
+This causes visibility=hidden problems for the Mac/Clang build.
+These patches will have the macros operate for the Mac.
+
+The first file (log/detail/setup_config.hpp) was fixed for 1.60, but FO uses 1.59
+See for details-  https://github.com/boostorg/log/pull/10
+
+The changse to iostreams/detail/config/dyn_link.hpp were submitted as a PR and have been merged.
+Details-  https://github.com/boostorg/iostreams/pull/34
+
+The third file locale/definitions.hpp was also submitted as a PR
+for the Boost repository, but it may be some time before the mod acts on it.
+Details-  https://github.com/boostorg/locale/pull/15
+
+---
+
+diff --git a/boost/log/detail/setup_config.hpp b/boost/log/detail/setup_config.hpp
+index fec50fb..28c6671 100644
+--- a/boost/log/detail/setup_config.hpp
++++ b/boost/log/detail/setup_config.hpp
+@@ -30,11 +30,17 @@
+ #        define BOOST_LOG_SETUP_DLL
+ #   endif
+ 
+-#   if defined(BOOST_HAS_DECLSPEC) && defined(BOOST_LOG_SETUP_DLL)
+-#       define BOOST_LOG_SETUP_API __declspec(dllimport)
+-#   else
++#   if defined(BOOST_LOG_SETUP_DLL)
++#       if defined(BOOST_SYMBOL_IMPORT)
++#           define BOOST_LOG_SETUP_API BOOST_SYMBOL_IMPORT
++#       elif defined(BOOST_HAS_DECLSPEC)
++#           define BOOST_LOG_SETUP_API __declspec(dllimport)
++#       endif
++#   endif
++#   ifndef BOOST_LOG_SETUP_API
+ #       define BOOST_LOG_SETUP_API
+-#   endif // defined(BOOST_HAS_DECLSPEC)
++#   endif
++
+ //
+ // Automatically link to the correct build variant where possible.
+ //
+@@ -48,12 +54,15 @@
+ 
+ #else // !defined(BOOST_LOG_SETUP_BUILDING_THE_LIB)
+ 
+-#   if defined(BOOST_HAS_DECLSPEC) && defined(BOOST_LOG_SETUP_DLL)
+-#       define BOOST_LOG_SETUP_API __declspec(dllexport)
+-#   elif defined(__GNUC__) && __GNUC__ >= 4 && (defined(linux) || defined(__linux) || defined(__linux__))
+-#       define BOOST_LOG_SETUP_API __attribute__((visibility("default")))
+-#   else
+-#       define BOOST_LOG_SETUP_API
++#   if defined(BOOST_LOG_SETUP_DLL)
++#       if defined(BOOST_SYMBOL_EXPORT)
++#           define BOOST_LOG_SETUP_API BOOST_SYMBOL_EXPORT
++#       elif defined(BOOST_HAS_DECLSPEC)
++#           define BOOST_LOG_SETUP_API __declspec(dllexport)
++#       endif
++#   endif
++#   ifndef BOOST_LOG_SETUP_API
++#       define BOOST_LOG_SETUP_API BOOST_SYMBOL_VISIBLE
+ #   endif
+ 
+ #endif // !defined(BOOST_LOG_SETUP_BUILDING_THE_LIB)
+
+
+diff --git a/boost/iostreams/detail/config/dyn_link.hpp b/boost/iostreams/detail/config/dyn_link.hpp
+index 518e0b0..47b037f 100755
+--- a/boost/iostreams/detail/config/dyn_link.hpp
++++ b/boost/iostreams/detail/config/dyn_link.hpp
+@@ -28,6 +28,15 @@
+ #   define BOOST_IOSTREAMS_DECL __declspec(dllimport)
+ #  endif  
+ # endif  
++//--------------Enable dynamic linking for non-windows---------------------//
++#else // BOOST_HAS_DECLSPEC
++# if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_IOSTREAMS_DYN_LINK)
++#  ifdef BOOST_IOSTREAMS_SOURCE
++#   define BOOST_IOSTREAMS_DECL BOOST_SYMBOL_EXPORT
++#  else
++#   define BOOST_IOSTREAMS_DECL BOOST_SYMBOL_IMPORT
++#  endif
++# endif
+ #endif 
+ 
+ #ifndef BOOST_IOSTREAMS_DECL
+
+
+diff --git a/boost/locale/definitions.hpp b/boost/locale/definitions.hpp
+index b305ff7..a98cec9 100644
+--- a/boost/locale/definitions.hpp
++++ b/boost/locale/definitions.hpp
+@@ -15,15 +15,13 @@
+ # define BOOST_SYMBOL_VISIBLE
+ #endif
+ 
+-#ifdef BOOST_HAS_DECLSPEC 
+-#   if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
+-#       ifdef BOOST_LOCALE_SOURCE
+-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
+-#       else
+-#           define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
+-#       endif  // BOOST_LOCALE_SOURCE
+-#   endif  // DYN_LINK
+-#endif  // BOOST_HAS_DECLSPEC
++#if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_LOCALE_DYN_LINK)
++#   ifdef BOOST_LOCALE_SOURCE
++#       define BOOST_LOCALE_DECL BOOST_SYMBOL_EXPORT
++#   else
++#       define BOOST_LOCALE_DECL BOOST_SYMBOL_IMPORT
++#   endif  // BOOST_LOCALE_SOURCE
++#endif  // DYN_LINK
+ 
+ #ifndef BOOST_LOCALE_DECL
+ #   define BOOST_LOCALE_DECL


### PR DESCRIPTION
This is intended to switch the Mac SDK build from 32 bit (i386) to 64 bit (x86_64), and to use the compiler flag -fvisibility=hidden (which is already in use for the FO code).

The README.md change is based on what I see with the Travis build.

Besides the x86 and visibility changes to CMakeLists.txt, the BUILD_SHARED_LIBS value was not being modified by cmake, due to it being a CACHE variable. Instead of using FORCE, I figured I would make the change where it is first assigned.

The new patch file is to make the Boost libraries work with the visibility hidden flag.
The Boost code only works with that compile flag when building dynamic shared libraries (plus some other preprocessor macros that are hard to find). Since the FO-SDK is making static libraries, this causes a bunch of variables to remain hidden, resulting in linking errors. I hand-assembled patches on a few of the `config` files to fix that situation.

After this PR is merged and run to make the Mac 64 bit libraries, the `dep` folder (with static libraries, frameworks, and includes) would need to be copied to the FO build (inside the `Xcode` folder), along with the PR to switch that Mac code to 64 bit.
That PR is 1585
https://github.com/freeorion/freeorion/pull/1585