### PR TITLE
Update PNG version to 1.34

### DIFF
--- a/Sources.cmake
+++ b/Sources.cmake
@@ -21,7 +21,7 @@ set(ZLIB_MD5 44d667c142d7cda120332623eab69f40)
 
 set(LIBPNG_VERSION 1.6.34)
 set(LIBPNG_URL https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.gz)
-set(LIBPNG_MD5 68553080685f812d1dd7a6b8215c37d8)
+set(LIBPNG_MD5 03fbc5134830240104e96d3cda648e71)
 
 set(PYTHON_CMAKE_URL https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/archive/9da2738063b6b5e16ea3578a95f7b93c6d44c9d2.zip)
 set(PYTHON_CMAKE_MD5 c77837daf2be404eeb85dee308831cd4)

--- a/Sources.cmake
+++ b/Sources.cmake
@@ -19,7 +19,7 @@ set(ZLIB_VERSION 1.2.8)
 set(ZLIB_URL http://downloads.sourceforge.net/project/libpng/zlib/${ZLIB_VERSION}/zlib-${ZLIB_VERSION}.tar.gz)
 set(ZLIB_MD5 44d667c142d7cda120332623eab69f40)
 
-set(LIBPNG_VERSION 1.6.29)
+set(LIBPNG_VERSION 1.6.34)
 set(LIBPNG_URL https://downloads.sourceforge.net/project/libpng/libpng16/${LIBPNG_VERSION}/libpng-${LIBPNG_VERSION}.tar.gz)
 set(LIBPNG_MD5 68553080685f812d1dd7a6b8215c37d8)
 


### PR DESCRIPTION
The download for libpng 1.29 is no longer at the expected location in

https://sourceforge.net/projects/libpng/files/libpng16/