### PR TITLE
Add option to parallelize boost compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
         - mkdir -p build
         - cd build
       script:
-        - cmake -G "Xcode" ..
+        - cmake -G "Xcode" -D BOOST_PARALLEL_JOBS=$(sysctl hw.ncpu | awk '{print $2}') ..
         - travis_wait 70 cmake --build . --config RelWithDebInfo -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
       deploy:
         provider: releases

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "Set the C++ standard the dependencies sh
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "Set the minimum OSX deployment target version")
 set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING "Set the architecture the binaries for OSX should be built for")
 set(CMAKE_INSTALL_MESSAGE NEVER CACHE STRING "Set the verbosity level for the install messages")
+set(BOOST_PARALLEL_JOBS 1 CACHE STRING "Set the Boost.Build parallel jobs")
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Set the default build configuration for this build" FORCE)
@@ -593,6 +594,7 @@ ExternalProject_Add(boost
     CONFIGURE_COMMAND ${BOOST_CONFIGURE_COMMAND}
     BUILD_COMMAND <SOURCE_DIR>/b2 install
         toolset=${BOOST_TOOLSET}
+        -j${BOOST_PARALLEL_JOBS}
         -d
         --layout=system
         --debug-configuration


### PR DESCRIPTION
Add option `BOOST_PARALLEL_JOBS` to parallelize boost compilation.

Should work on windows as well but I could not found why it got error.